### PR TITLE
Count all releases

### DIFF
--- a/script.rb
+++ b/script.rb
@@ -17,7 +17,10 @@ client = Octokit::Client.new(access_token: config[:github_access_token])
 
 t = 1.hour.ago.utc
 query = "org:artsy is:pr is:merged base:release merged:#{t.beginning_of_hour.iso8601}..#{t.end_of_hour.iso8601}"
-client.search_issues(query, page: 1, per_page: 100).items.each do |pr|
+releases = client.search_issues(query, page: 1, per_page: 100).items
+statsd.count 'release.release', releases.size # increment count of all releases
+
+releases.each do |pr|
   repo = pr.repository_url.split('/')[-2..-1].join('/')
   first_commit = client.pull_request_commits(repo, pr.number, per_page: 1).first
   next unless first_commit


### PR DESCRIPTION
This little script (which I'd almost forgotten about) runs in staging just to record our metric for the time from commit to release. This PR adds an additional count of all releases, in case we want to sum the total releases over time intervals.