### PR TITLE
Record new release.pull_request_age timing metric

### DIFF
--- a/script.rb
+++ b/script.rb
@@ -4,6 +4,7 @@
 require 'octokit'
 require 'active_support'
 require 'active_support/core_ext/numeric'
+require 'active_support/core_ext/time'
 require 'datadog/statsd'
 
 config = {
@@ -15,14 +16,52 @@ puts "Starting script with config #{config.map{|k,v| [k, v&.gsub(/.(?<=.{3})/,'*
 statsd = Datadog::Statsd.new(config[:dd_agent_host])
 client = Octokit::Client.new(access_token: config[:github_access_token])
 
+def pull_requests_for_release(issue, client)
+  query = <<-QUERY
+    query {
+      node(id: "#{issue.node_id}") {
+        ...on PullRequest {
+          commits(first: 100) {
+            edges {
+              node {
+                ...on PullRequestCommit {
+                  commit {
+                    associatedPullRequests(first:1) {
+                      edges {
+                        node {
+                          url
+                          createdAt
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  QUERY
+  response = client.post '/graphql', { query: query }.to_json
+  response.data.node.commits.edges.flat_map{|e| e.node.commit.associatedPullRequests.map{|k,v| v.first.node } }.uniq(&:url)
+end
+
 t = 1.hour.ago.utc
 query = "org:artsy is:pr is:merged base:release merged:#{t.beginning_of_hour.iso8601}..#{t.end_of_hour.iso8601}"
-client.search_issues(query, page: 1, per_page: 100).items.each do |pr|
-  repo = pr.repository_url.split('/')[-2..-1].join('/')
-  first_commit = client.pull_request_commits(repo, pr.number, per_page: 1).first
+client.search_issues(query, page: 1, per_page: 100).items.each do |release_pr|
+  # record time span between PR open and production release
+  pull_requests_for_release(release_pr, client).map do |pr|
+    age_s = release_pr.closed_at - Time.parse(pr.createdAt)
+    puts "Recording pull request age #{age_s} for pull request #{pr.url} in release #{release_pr.html_url}"
+    statsd.timing 'release.pull_request_age', age_s*1000 # milliseconds
+  end
+
+  repo = release_pr.repository_url.split('/')[-2..-1].join('/')
+  first_commit = client.pull_request_commits(repo, release_pr.number, per_page: 1).first
   next unless first_commit
 
-  cycle_time = pr.closed_at - first_commit.commit.author.date
-  puts "Recording cycle time #{cycle_time} for release #{pr.html_url}"
+  cycle_time = release_pr.closed_at - first_commit.commit.author.date
+  puts "Recording cycle time #{cycle_time} for release #{release_pr.html_url}"
   statsd.timing 'release.first_commit', cycle_time*1000 # milliseconds
 end


### PR DESCRIPTION
...reflecting span between PRs opening and releasing to production.

This depends on [associatedPullRequests](https://developer.github.com/v4/object/ref/) available in the v4/graphql API.

I've dry-run this enough times locally to convince myself it "works" so will self-merge in the interest of starting to collect data sooner rather than later. Feedback welcome though. (I recognize that this script is getting ugly enough to need a refactor.)