### PR TITLE
feat: add safe-to-evict flag to k8s cronjob spec, and misc.

### DIFF
--- a/hokusai/config.yml
+++ b/hokusai/config.yml
@@ -1,2 +1,6 @@
 ---
 project-name: frequency
+hokusai-required-version: ">=0.5.9"
+git-remote: git@github.com:artsy/frequency.git
+template-config-files:
+  - s3://artsy-citadel/k8s/hokusai-vars.yml

--- a/hokusai/staging.yml
+++ b/hokusai/staging.yml
@@ -8,7 +8,11 @@ spec:
   concurrencyPolicy: Forbid
   jobTemplate:
     spec:
+      backoffLimit: 0
       template:
+        metadata:
+          annotations:
+            "cluster-autoscaler.kubernetes.io/safe-to-evict": "false"
         spec:
           containers:
             - name: frequency-release-metrics
@@ -26,10 +30,9 @@ spec:
           restartPolicy: Never
           affinity:
             nodeAffinity:
-              preferredDuringSchedulingIgnoredDuringExecution:
-                - weight: 1
-                  preference:
-                    matchExpressions:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                  - matchExpressions:
                       - key: tier
                         operator: In
                         values:

--- a/hokusai/test.yml
+++ b/hokusai/test.yml
@@ -3,6 +3,5 @@ version: '2'
 services:
   frequency:
     command: ["echo", "no", "tests"]
-    extends:
-      file: build.yml
-      service: frequency
+    build:
+      context: ../


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/PLATFORM-3197

Update cronjob:

- Set `safe-to-evict` to `false` so it cannot be evicted by cluster-autoscaler.
- Set `backoffLimit` to `0` so there will be no retries upon failure. (it runs hourly anyway)