### PR TITLE
Provide explicit region to AWS connection

### DIFF
--- a/lib/config.rb
+++ b/lib/config.rb
@@ -6,6 +6,7 @@ class Config
   def self.load_config
     {
       aws_access_key_id: ENV['AWS_ACCESS_KEY_ID'],
+      aws_region: ENV['AWS_REGION'] || 'us-east-1',
       aws_secret_access_key: ENV['AWS_SECRET_ACCESS_KEY'],
       dd_agent_host: ENV['DD_AGENT_HOST'],
       github_access_token: ENV['GITHUB_ACCESS_TOKEN']

--- a/lib/data_freshness.rb
+++ b/lib/data_freshness.rb
@@ -21,7 +21,7 @@ class DataFreshness
     tag_count: { bucket: 'artsy-cinder-production', prefix: 'builds/TagCount/' },
     user_artwork_suggestions: { bucket: 'artsy-cinder-production', prefix: 'builds/UserArtworkSuggestions/' },
     user_genome: { bucket: 'artsy-cinder-production', prefix: 'builds/UserGenome/' },
-    user_price_preference: { bucket: 'artsy-cinder-production', prefix: 'builds/UserPricePreference/' },
+    user_price_preference: { bucket: 'artsy-cinder-production', prefix: 'builds/UserPricePreference/' }
   }
 
   def self.record_metrics
@@ -46,6 +46,7 @@ class DataFreshness
 
   def s3_client
     @s3_client ||= Aws::S3::Client.new(
+      region: Config.values[:aws_region],
       access_key_id: Config.values[:aws_access_key_id],
       secret_access_key: Config.values[:aws_secret_access_key]
     )


### PR DESCRIPTION
Fixes errors such as:

```
rake aborted!
Aws::Errors::MissingRegionError: No region was provided. Configure the `:region` option or export the region name to ENV['AWS_REGION']
...
```
