### PR TITLE
feat: log github graphql api error

### DIFF
--- a/lib/release_metrics.rb
+++ b/lib/release_metrics.rb
@@ -68,6 +68,9 @@ class ReleaseMetrics
       }
     QUERY
     response = github.post '/graphql', { query: query }.to_json
+    if response.errors.length > 0
+      $stderr.puts "Error: Retrieving pull requests from Github graphql API: #{response.errors}"
+    end
     response.data.node.commits.edges.flat_map do |e|
       e.node.commit.associatedPullRequests.map { |_k, v| v.first.node }
     end.uniq(&:url)


### PR DESCRIPTION
To make the [NoMethodError](https://my.papertrailapp.com/groups/3674473/events?q=host%3Afrequency+NoMethodError)s more intelligible.

Example from local run, hitting rate limit error and logging it:

```
artsy:frequency jxu$ foreman run bundle exec rake record:hourly_release_metrics
...
Error: Retrieving pull requests from Github graphql API: [{:type=>"RATE_LIMITED", :message=>"API rate limit exceeded for user ID 541332."}]
rake aborted!
NoMethodError: undefined method `node' for nil:NilClass
/Users/jxu/code/frequency/lib/release_metrics.rb:75:in `pull_requests_for_release'
/Users/jxu/code/frequency/lib/release_metrics.rb:20:in `block in record_hourly_metrics'
/Users/jxu/code/frequency/lib/release_metrics.rb:18:in `each'
/Users/jxu/code/frequency/lib/release_metrics.rb:18:in `record_hourly_metrics'
/Users/jxu/code/frequency/lib/release_metrics.rb:12:in `record_hourly_metrics'
/Users/jxu/code/frequency/Rakefile:16:in `block (2 levels) in <top (required)>'
/Users/jxu/.rbenv/versions/2.5.1/bin/bundle:23:in `load'
/Users/jxu/.rbenv/versions/2.5.1/bin/bundle:23:in `<main>'
Tasks: TOP => record:hourly_release_metrics
(See full trace by running task with --trace)
```