### PR TITLE
Track freshness of homefeed artist/artwork recommendations and trending scores

### DIFF
--- a/lib/data_freshness.rb
+++ b/lib/data_freshness.rb
@@ -21,8 +21,11 @@ class DataFreshness
     gene_partitioned_artist_trending: { bucket: 'artsy-cinder-production',
                                         prefix: 'builds/GenePartitionedArtistTrending/' },
     gene_similarity: { bucket: 'artsy-cinder-production', prefix: 'builds/GeneSimilarity/' },
+    homefeed_artist_reco: { bucket: 'artsy-recommendations', prefix: 'homefeed/artist_reco.csv' },
+    homefeed_artwork_reco: { bucket: 'artsy-recommendations', prefix: 'homefeed/artwork_reco.csv' },
     sitemaps: { bucket: 'artsy-sitemaps', prefix: 'sitemap-artist-series' }, # This is because in hue artist series is the last task to run in the chained sitemap tasks
     tag_count: { bucket: 'artsy-cinder-production', prefix: 'builds/TagCount/' },
+    trending_score: { bucket: 'artsy-recommendations', prefix: 'trending_score/' },
     user_artwork_suggestions: { bucket: 'artsy-cinder-production', prefix: 'builds/UserArtworkSuggestions/' },
     user_genome: { bucket: 'artsy-cinder-production', prefix: 'builds/UserGenome/' },
     user_price_preference: { bucket: 'artsy-cinder-production', prefix: 'builds/UserPricePreference/' }


### PR DESCRIPTION
This adds artist/artwork recommendations and artwork trending scores to the other artifacts tracked in [this freshness dashboard](https://app.datadoghq.com/dashboard/b94-6dq-m3a/data-freshness).

The usual hourly cron will record the age of each specified S3 artifact to Datadog as a custom `gauge` metric. Then we can modify the dashboard to reflect the new metrics.

It's possible for these pipelines to fail (or be delayed) at a _later_ step, such as copying to Redshift or importing to Vortex, so these metrics won't be exhaustive. However, they'll at least allow us to get visibility into the results and timeliness of the recommendations logic.