### PR TITLE
Tolerate nil errors on Github responses

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,3 +17,7 @@ gem 'rubocop'
 group :test do
   gem 'rspec'
 end
+
+group :development, :test do
+  gem 'byebug'
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -26,6 +26,7 @@ GEM
     aws-sigv4 (1.2.3)
       aws-eventstream (~> 1, >= 1.0.2)
     base64 (0.1.1)
+    byebug (11.1.3)
     concurrent-ruby (1.1.6)
     diff-lcs (1.4.4)
     dogstatsd-ruby (4.5.0)
@@ -88,6 +89,7 @@ DEPENDENCIES
   activesupport
   aws-sdk-s3
   base64
+  byebug
   dogstatsd-ruby
   json
   jwt

--- a/lib/release_metrics.rb
+++ b/lib/release_metrics.rb
@@ -5,6 +5,7 @@ require 'active_support'
 require 'active_support/core_ext/numeric'
 require 'active_support/core_ext/time'
 require 'datadog/statsd'
+require 'json'
 require_relative './config'
 
 # Records cycle time metrics for releases in the last hour.
@@ -69,8 +70,9 @@ class ReleaseMetrics
         }
       }
     QUERY
+
     response = github.post '/graphql', { query: query }.to_json
-    if response.errors.length.positive?
+    if response.errors&.length&.positive?
       warn "Error: Retrieving pull requests from Github graphql API: #{response.errors}"
     end
     response.data.node.commits.edges.flat_map do |e|

--- a/spec/lib/release_metrics_spec.rb
+++ b/spec/lib/release_metrics_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require_relative '../../lib/release_metrics'
+
+describe ReleaseMetrics do
+  let(:github_client) { double(Octokit::Client) }
+  let(:response) { double('Sawyer::Resource') }
+  let(:issue) { double('Issue', node_id: 'foo') }
+
+  before do
+    allow(Octokit::Client).to receive(:new).and_return(github_client)
+    allow(github_client).to receive(:post).and_return(response)
+  end
+
+  it 'tolerates nil errors' do
+    allow(response).to receive_messages(
+      errors: nil,
+      data: double(node: double(commits: double(edges: [])))
+    )
+    expect(ReleaseMetrics.new.pull_requests_for_release(issue)).to eq([])
+  end
+end


### PR DESCRIPTION
Our release metrics dropped off in March!

<img width="1856" alt="Screen Shot 2022-06-15 at 3 36 06 PM" src="https://user-images.githubusercontent.com/28120/173910177-7590c784-58ac-4cf7-a10a-00e690a8cd5a.png">

Apparently the `errors` property returned by Github's API client can be `nil` now. This PR handles that more gracefully.