### PR TITLE
Load commits from Github API into Redshift (PLATFORM-4263)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,7 @@ gem 'dogstatsd-ruby'
 gem 'json'
 gem 'jwt'
 gem 'octokit' # release metrics
+gem 'pg' # merge data into redshift
 gem 'rake'
 gem 'rubocop'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -44,6 +44,7 @@ GEM
     parallel (1.22.1)
     parser (3.1.1.0)
       ast (~> 2.4.1)
+    pg (1.4.1)
     public_suffix (4.0.6)
     rainbow (3.1.1)
     rake (13.0.3)
@@ -94,6 +95,7 @@ DEPENDENCIES
   json
   jwt
   octokit
+  pg
   rake
   rspec
   rubocop

--- a/Rakefile
+++ b/Rakefile
@@ -28,3 +28,10 @@ task :scan_tokens do
   require './lib/token_scanner'
   TokenScanner.new.run
 end
+
+namespace :commits do
+  task :load do
+    require './lib/commits_loader'
+    CommitsLoader.load_recent_commits
+  end
+end

--- a/hokusai/production.yml
+++ b/hokusai/production.yml
@@ -1,3 +1,4 @@
+---
 apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
@@ -21,6 +22,50 @@ spec:
             - exec
             - rake
             - hourly
+            imagePullPolicy: Always
+            envFrom:
+            - configMapRef:
+                name: frequency-environment
+            env:
+            - name: DD_AGENT_HOST
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          restartPolicy: Never
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: tier
+                    operator: In
+                    values:
+                    - background
+
+---
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: frequency-commits-load
+spec:
+  schedule: 11 3 * * *
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      backoffLimit: 0
+      template:
+        metadata:
+          annotations:
+            cluster-autoscaler.kubernetes.io/safe-to-evict: 'false'
+        spec:
+          containers:
+          - name: frequency-release-metrics
+            image: 585031190124.dkr.ecr.us-east-1.amazonaws.com/frequency:production
+            command:
+            - bundle
+            - exec
+            - rake
+            - commits:load
             imagePullPolicy: Always
             envFrom:
             - configMapRef:

--- a/lib/aws_helper.rb
+++ b/lib/aws_helper.rb
@@ -1,0 +1,19 @@
+require 'aws-sdk-s3'
+require_relative './config'
+
+class AwsHelper
+  def self.s3_client
+    @s3_client ||= Aws::S3::Client.new(
+      region: Config.values[:aws_region],
+      access_key_id: Config.values[:aws_access_key_id],
+      secret_access_key: Config.values[:aws_secret_access_key]
+    )
+  end
+
+  def self.credentials_for_sql
+    [
+      "aws_access_key_id=#{Config.values[:aws_access_key_id]}",
+      "aws_secret_access_key=#{Config.values[:aws_secret_access_key]}"
+    ].join(';')
+  end
+end

--- a/lib/commits_loader.rb
+++ b/lib/commits_loader.rb
@@ -1,0 +1,190 @@
+# frozen_string_literal: true
+
+require 'active_support'
+require 'active_support/core_ext/numeric'
+require 'active_support/core_ext/time'
+require 'json'
+require 'tempfile'
+require 'csv'
+require 'zlib'
+require 'pg'
+require_relative './github'
+require_relative './aws_helper'
+
+class CommitsLoader
+  HEADERS = %i[object_id repository message_headline message author_name authored_date committed_date pushed_date]
+  BUCKET = 'artsy-data'
+
+  def self.load_recent_commits
+    new.load_recent_commits
+  end
+
+  def initialize(since: 30.days.ago, _until: nil, org: "artsy")
+    @since = since
+    @until = _until
+    @org = org
+  end
+
+  def load_recent_commits
+    data = build_data
+    s3_object = upload_to_s3(data)
+    merge_into_warehouse(s3_object)
+  end
+
+  private
+
+  def build_data
+    data = []
+    each_recently_pushed_repo do |repo|
+      each_recently_pushed_commit(repo) do |commit|
+        data << {
+          object_id: commit.oid,
+          repository: repo.name,
+          message_headline: commit.messageHeadline,
+          message: commit.message,
+          author_name: commit.author.name,
+          authored_date: commit.authoredDate,
+          committed_date: commit.committedDate,
+          pushed_date: commit.pushedDate
+        }
+      end
+    end
+    data
+  end
+
+  def upload_to_s3(data)
+    key = "reports/engineering.commits/partial_#{Time.now.to_s(:number)}.csv.gz"
+    $stderr.puts "Uploading to #{BUCKET} #{key}..."
+    s3_object = Aws::S3::Object.new(BUCKET, key, client: AwsHelper.s3_client)
+    s3_object.upload_stream(tempfile: true) do |s3_stream|
+      s3_stream.binmode
+      Zlib::GzipWriter.wrap(s3_stream) do |gzw|
+        CSV(gzw, headers: HEADERS, write_headers: true) do |csv|
+          data.each { |row| csv << row }
+        end
+      end
+    end
+    s3_object
+  end
+
+  def merge_into_warehouse(s3_object)
+    pg = PG.connect(Config.values[:redshift_url])
+    begin
+      $stderr.puts "Loading recent data into warehouse..."
+      pg.exec(merge_query(s3_object))
+    ensure
+      pg.close
+    end
+  end
+
+  def each_recently_pushed_repo
+    cursor = nil
+    loop do
+      response = Github.execute_query(repo_query(cursor))
+      response.data.repositoryOwner.repositories.nodes.each do |repo|
+        $stderr.puts "Processing repo: #{repo.name} #{repo.pushedAt}"
+        return if Time.parse(repo.pushedAt) < @since
+
+        yield repo
+      end
+      return unless response.data.repositoryOwner.repositories.pageInfo.hasNextPage
+      cursor = response.data.repositoryOwner.repositories.pageInfo.endCursor
+    end
+  end
+
+  def each_recently_pushed_commit(repo)
+    cursor = nil
+    loop do
+      response = Github.execute_query(commit_query(repo, cursor))
+      response.data.repository.defaultBranchRef.target.history.nodes.each do |commit|
+        $stderr.puts "\tProcessing commit: #{commit.oid} on #{repo.name} (#{commit.committedDate})..."
+        yield commit
+      end
+      return unless response.data.repository.defaultBranchRef.target.history.pageInfo.hasNextPage
+      cursor = response.data.repository.defaultBranchRef.target.history.pageInfo.endCursor
+    end
+  end
+
+  def repo_query(cursor)
+    <<-QUERY
+      query {
+        repositoryOwner(login: #{@org.to_json}) {
+          repositories(first: 100, orderBy: {direction: DESC, field: PUSHED_AT}#{", after: #{cursor.to_json}" if cursor}) {
+            pageInfo {
+              hasNextPage
+              endCursor
+            }
+            nodes {
+              name
+              pushedAt
+            }
+          }
+        }
+      }
+    QUERY
+  end
+
+  def commit_query(repo, cursor)
+    <<-QUERY
+      query {
+        repository(owner: #{@org.to_json}, name: #{repo.name.to_json}) {
+          defaultBranchRef {
+            target {
+              ... on Commit {
+                history(first: 100, since: #{@since&.utc&.iso8601.to_json}, until: #{@until&.utc&.iso8601.to_json}#{", after: #{cursor.to_json}" if cursor}) {
+                  pageInfo {
+                    hasNextPage
+                    endCursor
+                  }
+                  nodes {
+                    messageHeadline
+                    oid
+                    message
+                    author {
+                      name
+                      email
+                      date
+                    }
+                    pushedDate
+                    authoredDate
+                    committedDate
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    QUERY
+  end
+
+  def merge_query(s3_object)
+    <<-SQL
+      create temporary table commits_staged (like engineering.commits);
+
+      copy commits_staged from 's3://#{s3_object.bucket.name}/#{s3_object.key}'
+        with credentials '#{AwsHelper.credentials_for_sql}'
+        csv
+        ignoreheader 1
+        emptyasnull
+        acceptinvchars
+        gzip
+        timeformat 'auto'
+        dateformat 'auto'
+        truncatecolumns;
+
+      begin transaction;
+
+      delete from engineering.commits
+      using commits_staged
+      where engineering.commits.object_id = commits_staged.object_id;
+
+      insert into engineering.commits
+      select * from commits_staged;
+
+      end transaction;
+
+      drop table commits_staged;
+    SQL
+  end
+end

--- a/lib/config.rb
+++ b/lib/config.rb
@@ -12,7 +12,8 @@ class Config
       aws_region: ENV['AWS_REGION'] || 'us-east-1',
       aws_secret_access_key: ENV['AWS_SECRET_ACCESS_KEY'],
       dd_agent_host: ENV['DD_AGENT_HOST'],
-      github_access_token: ENV['GITHUB_ACCESS_TOKEN']
+      github_access_token: ENV['GITHUB_ACCESS_TOKEN'],
+      redshift_url: ENV['REDSHIFT_URL']
     }.tap do |config|
       warn "Loading config #{config.map { |k, v| [k, v&.gsub(/.(?<=.{3})/, '*')].join(':') }.join(', ')}"
     end

--- a/lib/github.rb
+++ b/lib/github.rb
@@ -1,0 +1,18 @@
+require 'octokit'
+require 'json'
+require_relative './config'
+
+class Github
+  # contruct and memoize a client object
+  def self.client
+    @client ||= Octokit::Client.new(access_token: Config.values[:github_access_token])
+  end
+
+  def self.execute_query(query)
+    response = client.post '/graphql', { query: query }.to_json
+    if response.errors&.length&.positive?
+      warn "Error: Retrieving results from Github graphql API: #{response.errors}"
+    end
+    response
+  end
+end


### PR DESCRIPTION
A new `commits:load` task sources recent commits from the "default" branch (`main`) of each `artsy` org repository and uploads them in CSV format to S3. A later step follows [AWS's recommendation](https://docs.aws.amazon.com/redshift/latest/dg/merge-replacing-existing-rows.html) for merging that data into a Redshift table via a temporary "staging" table (to avoid duplicates).

There's some unfortunate complexity to construct the verbose graphql queries accurately, and to handle arbitrary cursor-based pagination within the results, but now that this works it provides an easier-to-maintain alternative to the vulnerability extract.

### To run locally:

```bash
foreman run bundle exec rake commits:load
```

### Set-up and back-fill

To create the new destination table, I ran in a Redshift query editor:

```sql
CREATE TABLE engineering.commits (
  object_id varchar(40) PRIMARY KEY,
  repository varchar(128),
  message_headline text,
  message text,
  author_name varchar(64),
  authored_date timestamp,
  committed_date timestamp SORTKEY,
  pushed_date timestamp
)
```

To back-fill the last ~90 days or so of commits I ran in a local `foreman run irb` console:

```ruby
(0..13).each{|i| puts "WEEK #{i}"; CommitsLoader.new(since: (i + 1).weeks.ago.utc, _until: i.weeks.ago.utc).load_recent_commits }; nil
```

### To dos

**Automate this job every day or so:** This repo doesn't yet have a production environment! Since it deals with the development cycle itself, it was never clear how separate "staging" and "production" environments should operate or if they even made sense. This task is the first time an operation needs access to the production VPC, so I think we should probably introduce a production environment, copy the config map over, and scope the release and data freshness dashboards to the `env:production` tag.

(However, we can safely run this task manually while on the production VPC in the meantime.)

**Aggregate over these commit messages:** We should be able to identify "features" vs. "fixes" and "chores." It'll also be worth identifying and correctly classifying likely merges and reverts based on Github's common format for those messages.

https://artsyproduct.atlassian.net/browse/PLATFORM-4263