### PR TITLE
Create production environment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,6 +2,7 @@ version: 2.1
 
 orbs:
   hokusai: artsy/hokusai@volatile
+  horizon: artsy/release@volatile
 
 not_staging_or_release: &not_staging_or_release
   filters:
@@ -16,9 +17,20 @@ only_main: &only_main
     branches:
       only: main
 
+only_release: &only_release
+  context: hokusai
+  filters:
+    branches:
+      only: release
+
 workflows:
   build-deploy:
     jobs:
+      - horizon/block:
+          <<: *only_release
+          context: horizon
+          project_id: 267
+
       - hokusai/test:
           <<: *not_staging_or_release
 
@@ -33,3 +45,8 @@ workflows:
           project-name: frequency
           requires:
             - push-staging-image
+
+      - hokusai/deploy-production:
+          <<: *only_release
+          requires:
+            - horizon/block

--- a/hokusai/production.yml
+++ b/hokusai/production.yml
@@ -15,10 +15,12 @@ spec:
         spec:
           containers:
           - name: frequency-release-metrics
-            image: 585031190124.dkr.ecr.us-east-1.amazonaws.com/frequency:staging
+            image: 585031190124.dkr.ecr.us-east-1.amazonaws.com/frequency:production
             command:
-            - echo
-            - noop
+            - bundle
+            - exec
+            - rake
+            - hourly
             imagePullPolicy: Always
             envFrom:
             - configMapRef:


### PR DESCRIPTION
Add production deployment and switch staging cron to noop (to avoid double-counting metrics).

At some point in the future, dashboards could be scoped to the `env:production` tag, and a cron could be reintroduced in staging.