### PR TITLE
feat: Record hourly image resize latency (PLATFORM-4628)

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -7,7 +7,7 @@ rescue LoadError
 end
 
 desc 'run both metrics tasks hourly'
-task hourly: ['record:hourly_release_metrics', 'record:data_freshness']
+task hourly: ['record:hourly_release_metrics', 'record:data_freshness', 'record:image_latency']
 
 namespace :record do
   desc 'Record hourly release.first_commit and release.pull_request_age metrics to statsd'
@@ -20,6 +20,12 @@ namespace :record do
   task :data_freshness do
     require './lib/data_freshness'
     DataFreshness.record_metrics
+  end
+
+  desc 'Record latency of image transformations'
+  task :image_latency do
+    require './lib/image_latency'
+    ImageLatency.record_metrics
   end
 end
 

--- a/lib/image_latency.rb
+++ b/lib/image_latency.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require 'securerandom'
+require 'datadog/statsd'
+require_relative './config'
+
+# Records timeliness of data-processing tasks' results on S3
+class ImageLatency
+  IMAGE_URL = 'https://d7hftxdivxxvm.cloudfront.net/?resize_to=fit&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FMQ5HiQrrZ-vOIpkEVNBomg%2Flarge.jpg&width=890&height=1186&quality=80'
+  ACCEPT_HEADER = 'image/avif,image/webp,image/apng,image/svg+xml,image/*,*/*;q=0.8'
+
+  def self.record_metrics
+    new.record_metrics
+  end
+
+  def record_metrics
+    url = "#{IMAGE_URL}&rand=#{SecureRandom.hex}" # append random param to ensure CDN cache miss
+    command = "curl -H 'Accept: #{ACCEPT_HEADER}' '#{url}'"
+    warn "Running: #{command}"
+    start = Time.now
+    `#{command}`
+    latency = Time.now - start
+    warn "Recording image_latency as #{latency}"
+    statsd.gauge "image_latency", latency # seconds
+  end
+
+  def statsd
+    @statsd ||= Datadog::Statsd.new(Config.values[:dd_agent_host])
+  end
+end


### PR DESCRIPTION
A little experiment in service of https://artsyproduct.atlassian.net/browse/PLATFORM-4628: measure the latency of a standard image transformation from a standard location with a typical `Accept` header on a repeating hourly basis.

This should confirm higher latency during the day, lower latency from infrastructure changes, or lower latency from imagemagick alternatives.