### PR TITLE
feat: Add dd-agent for local dev. And fix spot price task.

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,14 +20,20 @@ Some of the tasks in this repo send metrics to Datadog via [dogstatsd](https://g
 
 - Spin up a local dd-agent using Hokusai:
 
+    ```
     hokusai dev start
+    ```
 
 - Run the task locally, for example:
 
+    ```
     foreman run bundle exec rake record:data_freshness
+    ```
 
 - You can also run the task via Hokusai:
 
+    ```
     hokusai dev run "bundle exec rake record:data_freshness"
+    ```
 
-- Confirm it works by locating the metric on [Datadog Metrics Explorer UI](https://app.datadoghq.com/metric/explorer).
+- Confirm it works by locating the metric on [Datadog Metrics Explorer UI](https://app.datadoghq.com/metric/explorer). There's a lag of a few minutes.

--- a/README.md
+++ b/README.md
@@ -13,3 +13,21 @@ To run tests:
 To run tasks locally (e.g.):
 
     foreman run bundle exec rake record:data_freshness
+
+## Testing Datadog
+
+Some of the tasks in this repo send metrics to Datadog via [dogstatsd](https://github.com/DataDog/dogstatsd-ruby). If you are adding a task that does something similar, you might want to test sending metric from your local to Datadog. You can do that by:
+
+- Spin up a local dd-agent using Hokusai:
+
+    hokusai dev start
+
+- Run the task locally, for example:
+
+    foreman run bundle exec rake record:data_freshness
+
+- You can also run the task via Hokusai:
+
+    hokusai dev run "bundle exec rake record:data_freshness"
+
+- Confirm it works by locating the metric on [Datadog Metrics Explorer UI](https://app.datadoghq.com/metric/explorer).

--- a/Rakefile
+++ b/Rakefile
@@ -28,7 +28,7 @@ namespace :record do
     ImageLatency.record_metrics
   end
 
-  desc 'Record spot price'
+  desc 'Record AWS Spot instances price'
   task :spot_price do
     require './lib/spot_price'
     SpotPrice.record_metrics

--- a/hokusai/development.yml
+++ b/hokusai/development.yml
@@ -2,9 +2,22 @@
 version: '2'
 services:
   frequency:
-    env_file: ../.env
-    extends:
-      file: build.yml
-      service: frequency
+    env_file:
+    - ../.env.shared
+    - ../.env
+    environment:
+      - DD_AGENT_HOST=dd-agent
+    build:
+      context: ../
     volumes:
       - ../:/app
+    depends_on:
+      - dd-agent
+  dd-agent:
+    env_file:
+    - ../.env.shared
+    - ../.env
+    image: datadog/agent:6.22.0
+    ports:
+    - "8125:8125/udp"
+    - "8126:8126/tcp"

--- a/lib/config.rb
+++ b/lib/config.rb
@@ -11,7 +11,7 @@ class Config
       aws_access_key_id: ENV['AWS_ACCESS_KEY_ID'],
       aws_region: ENV['AWS_REGION'] || 'us-east-1',
       aws_secret_access_key: ENV['AWS_SECRET_ACCESS_KEY'],
-      dd_agent_host: ENV['DD_AGENT_HOST'],
+      dd_agent_host: ENV['DD_AGENT_HOST'] || 'localhost',
       github_access_token: ENV['GITHUB_ACCESS_TOKEN'],
       redshift_url: ENV['REDSHIFT_URL']
     }.tap do |config|

--- a/lib/spot_price.rb
+++ b/lib/spot_price.rb
@@ -11,7 +11,9 @@ class SpotPrice
   def record_metrics
     # instance types we allow in Spot instance groups.
     %w(c5.xlarge r5.xlarge m5.xlarge c6i.xlarge r6i.xlarge m6i.xlarge).each do |instance_type|
-      statsd.gauge "spot_price", get_spot_price(instance_type), {:tags => [instance_type]}
+      price = get_spot_price(instance_type)
+      statsd.gauge("spot_price", price, tags: ["spot_instance_type:#{instance_type}"])
+      warn "Recorded price for #{instance_type} Spot instance: #{price} (0 means failure to obtain price)"
     end
   end
 


### PR DESCRIPTION
[PLATFORM-4681]
Follows https://github.com/artsy/frequency/pull/42

- [Fix](https://artsy.slack.com/archives/CA8SANW3W/p1666378664106629) tagging of `spot_price` task.
- Add dd-agent to hokusai dev, so metric sending can be tested locally.

The following vars are added to .env.shared on S3:
```
DD_API_KEY
DD_DOGSTATSD_NON_LOCAL_TRAFFIC
DD_ENV
DD_LOG_LEVEL
```

Tags [confirmed](https://app.datadoghq.com/metric/explorer?start=1666723626906&end=1666727015141&paused=true#N4IgNghgng9grgFxALlADxQRgDQil3AdwEsATBACwJAoFNiBzCpZTAX11NoDNiA7YgmIw+KUAigAHWihBCAtrQDOtAE7FlIXKtoBHOMoRKUAbVA6lkkSoD63GKvkQWc4opXrNufWo3HkZiB8EIqyPqpQmFogpM4QNkrwqgDGMsggigjqycbeBhGyEABuDMiWMAg2ktm0wLR8RchcRWwABABGUK3A5ZX8SggQfKk2EtJsIGwAurj2jnCQ-oFz8gsQYfmRkzMgA1BgaaCSEAcICGkxMAw2yYtKxMnRYPy0o1IXic+kTy82JORUdJ8BxOMCTTjESyQKBvaSyZ58GTTNhsIA) to be working.

[PLATFORM-4681]: https://artsyproduct.atlassian.net/browse/PLATFORM-4681?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ