### PR TITLE
feat: token scanner task logs audience and subject ids

### DIFF
--- a/lib/token_scanner.rb
+++ b/lib/token_scanner.rb
@@ -47,7 +47,12 @@ class TokenScanner
         next unless decoded_jwt[0].key?('exp')
 
         days_left = get_days_left(decoded_jwt[0]['exp'])
-        results << [name, key, days_left] if days_left < WARN_THRESHOLD
+
+        aud_id = decoded_jwt[0]['aud']
+
+        sub_id = decoded_jwt[0]['subject_application']
+
+        results << [name, key, days_left, aud_id, sub_id] if days_left < WARN_THRESHOLD
       end
     end
   end
@@ -85,7 +90,9 @@ class TokenScanner
       puts "Context: #{context}"
       results.each do |result|
         expiration = result[2].positive? ? "expires-in: #{result[2]} days" : "expired: #{result[2].abs} days ago"
-        puts "\tconfigmap: #{result[0]}, key: #{result[1]}, #{expiration}."
+        puts "\tconfigmap: #{result[0]}"
+        puts "\t\t key: #{result[1]}, #{expiration}."
+        puts "\t\t audience_id = #{result[3]}, subject_id = #{result[4]}"
       end
     end
     puts 'END'

--- a/lib/token_scanner.rb
+++ b/lib/token_scanner.rb
@@ -91,8 +91,7 @@ class TokenScanner
       results.each do |result|
         expiration = result[2].positive? ? "expires-in: #{result[2]} days" : "expired: #{result[2].abs} days ago"
         puts "\tconfigmap: #{result[0]}"
-        puts "\t\t key: #{result[1]}, #{expiration}."
-        puts "\t\t audience_id = #{result[3]}, subject_id = #{result[4]}"
+        puts "\t\t key: #{result[1]}, #{expiration}, audience_id: #{result[3]}, subject_id: #{result[4]}"
       end
     end
     puts 'END'


### PR DESCRIPTION
As I was updating the [playbook](https://www.notion.so/artsy/Engineering-Playbooks-b655fe54c1ce4b35af342c9ed9a489ae#340fd67cd1a8491da0dfc6beec929950) it occurred to me that logging IDs of both _audience_ and _subject_ would make it so that the renewal process would require less steps if those IDs were already known.

This way one can reference the email and execute the [new rake task](https://github.com/artsy/gravity/blob/main/lib/tasks/token.rake) without having to enter gravity console to lookup IDs or without having to decode the existing JWT to get those values.

Feel free to close this if this isn't something that you think we should add.

New output format is:
```
Context: staging
	configmap: app1-environment
		 key: JWT_TEST_TOKEN, expires-in: 13 days.
		 audience_id = 12345, subject_id = 12345
	configmap: app2-environment
		 key: JWT_TEST_TOKEN, expired: 1 days ago.
		 audience_id = 12345, subject_id = 67890
```
