### PR TITLE
fix: rebuild vulnerabilities extract based on prior examples #migration

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -6,7 +6,7 @@ begin
 rescue LoadError
 end
 
-desc 'run both metrics tasks hourly'
+desc 'run all metrics tasks hourly'
 task hourly: ['record:hourly_release_metrics', 'record:data_freshness', 'record:image_latency', 'record:spot_price']
 
 namespace :record do
@@ -45,5 +45,12 @@ namespace :commits do
   task :load do
     require './lib/commits_loader'
     CommitsLoader.load_recent_commits
+  end
+end
+
+namespace :vulnerabilities do
+  task :extract do
+    require './lib/vulnerabilities_extract'
+    VulnerabilitiesExtract.extract_vulnerabilities
   end
 end

--- a/hokusai/production.yml
+++ b/hokusai/production.yml
@@ -59,13 +59,57 @@ spec:
             cluster-autoscaler.kubernetes.io/safe-to-evict: 'false'
         spec:
           containers:
-          - name: frequency-release-metrics
+          - name: frequency-commits-load
             image: 585031190124.dkr.ecr.us-east-1.amazonaws.com/frequency:production
             command:
             - bundle
             - exec
             - rake
             - commits:load
+            imagePullPolicy: Always
+            envFrom:
+            - configMapRef:
+                name: frequency-environment
+            env:
+            - name: DD_AGENT_HOST
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          restartPolicy: Never
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: tier
+                    operator: In
+                    values:
+                    - background
+
+---
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: frequency-vulnerabilities-extract
+spec:
+  schedule: 01 5 * * *
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      backoffLimit: 0
+      template:
+        metadata:
+          annotations:
+            cluster-autoscaler.kubernetes.io/safe-to-evict: 'false'
+        spec:
+          containers:
+          - name: frequency-vulnerabilities-extract
+            image: 585031190124.dkr.ecr.us-east-1.amazonaws.com/frequency:production
+            command:
+            - bundle
+            - exec
+            - rake
+            - vulnerabilities:extract
             imagePullPolicy: Always
             envFrom:
             - configMapRef:

--- a/lib/vulnerabilities_extract.rb
+++ b/lib/vulnerabilities_extract.rb
@@ -1,0 +1,129 @@
+# frozen_string_literal: true
+
+require 'active_support'
+require 'active_support/core_ext/numeric'
+require 'active_support/core_ext/time'
+require 'json'
+require_relative './github'
+require_relative './aws_helper'
+
+class VulnerabilitiesExtract
+  HEADERS = %i[repository vulnerability_id package created_at dismissed_at fixed_at state severity description]
+  BUCKET = 'artsy-data'
+
+  def self.extract_vulnerabilities
+    new.extract_vulnerabilities
+  end
+
+  def initialize(org: "artsy")
+    @org = org
+  end
+
+  def extract_vulnerabilities
+    data = build_data
+    AwsHelper.upload_csv_to_s3(
+      BUCKET,
+      "reports/engineering.vulnerabilities/export_#{Time.now.to_s(:number)}.csv.gz",
+      HEADERS,
+      data
+    )
+  end
+
+  private
+
+  def build_data
+    data = []
+    each_repo do |repo|
+      each_vulnerability(repo) do |vuln|
+        data << {
+          repository: repo.name,
+          vulnerability_id: vuln.id,
+          package: vuln.securityVulnerability.package.name,
+          created_at: vuln.createdAt,
+          dismissed_at: vuln.dismissedAt,
+          fixed_at: vuln.fixedAt,
+          state: vuln.state,
+          severity: vuln.securityVulnerability.severity,
+          description: vuln.securityVulnerability.advisory.description
+        }
+      end
+    end
+    data
+  end
+
+  def each_repo
+    cursor = nil
+    loop do
+      response = Github.execute_query(repo_query(cursor))
+      response.data.repositoryOwner.repositories.nodes.each do |repo|
+        $stderr.puts "Processing repo: #{repo.name} #{repo.pushedAt}"
+        yield repo
+      end
+      return unless response.data.repositoryOwner.repositories.pageInfo.hasNextPage
+      cursor = response.data.repositoryOwner.repositories.pageInfo.endCursor
+    end
+  end
+
+  def each_vulnerability(repo)
+    cursor = nil
+    loop do
+      response = Github.execute_query(vulnerability_query(repo, cursor))
+      response.data.repository.vulnerabilityAlerts.nodes.each do |vuln|
+        $stderr.puts "\tProcessing vulnerability alert: #{vuln.id} on #{repo.name}..."
+        yield vuln
+      end
+      return unless response.data.repository.vulnerabilityAlerts.pageInfo.hasNextPage
+      cursor = response.data.repository.vulnerabilityAlerts.pageInfo.endCursor
+    end
+  end
+
+  def repo_query(cursor)
+    <<-QUERY
+      query {
+        repositoryOwner(login: #{@org.to_json}) {
+          repositories(first: 100, orderBy: {direction: DESC, field: PUSHED_AT}#{", after: #{cursor.to_json}" if cursor}) {
+            pageInfo {
+              hasNextPage
+              endCursor
+            }
+            nodes {
+              name
+              pushedAt
+            }
+          }
+        }
+      }
+    QUERY
+  end
+
+  def vulnerability_query(repo, cursor)
+    <<-QUERY
+      query {
+        repository(owner: #{@org.to_json}, name: #{repo.name.to_json}) {
+          vulnerabilityAlerts(first: 100#{", after: #{cursor.to_json}" if cursor}) {
+            nodes {
+              id
+              createdAt
+              dismissedAt
+              fixedAt
+              state
+              securityVulnerability {
+                package {
+                  name
+                }
+                advisory {
+                  description
+                }
+                severity
+              }
+            }
+            pageInfo {
+              endCursor
+              hasNextPage
+            }
+          }
+        }
+      }
+    QUERY
+  end
+end


### PR DESCRIPTION
The [vulnerabilities extract job](https://joe.artsy.net/view/All/job/vulnerabilities-extract-cron/):lock:, originally composed in `bash`, has been failing for a while, because `jq` is no longer available in the jenkins environment.

I'm taking this opportunity to move the job out of Jenkins, and from bash (where it was extremely difficult to understand and fix) to ruby. [The `CommitsLoader` example](https://github.com/artsy/frequency/blob/main/lib/commits_loader.rb), which already integrates with Github and AWS, made this pretty easy.

I've already disabled the Jenkins job. **Once released, I'll delete it.**