### PR TITLE
feat: add staging cronjob for report extract

### DIFF
--- a/hokusai/staging.yml
+++ b/hokusai/staging.yml
@@ -38,3 +38,46 @@ spec:
                     operator: In
                     values:
                     - background
+---
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: frequency-vulnerabilities-extract
+spec:
+  schedule: 01 4 * * *
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      backoffLimit: 0
+      template:
+        metadata:
+          annotations:
+            cluster-autoscaler.kubernetes.io/safe-to-evict: 'false'
+        spec:
+          containers:
+          - name: frequency-vulnerabilities-extract
+            image: 585031190124.dkr.ecr.us-east-1.amazonaws.com/frequency:staging
+            command:
+            - bundle
+            - exec
+            - rake
+            - vulnerabilities:extract
+            imagePullPolicy: Always
+            envFrom:
+            - configMapRef:
+                name: frequency-environment
+            env:
+            - name: DD_AGENT_HOST
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          restartPolicy: Never
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: tier
+                    operator: In
+                    values:
+                    - background


### PR DESCRIPTION
Adds daily scheduled task to extract vulnerabilities data to artsy-data-staging bucket.

Migration: REPORTS_BUCKET and REDSHIFT_URL have been added/updated in staging and production configmaps.