### PR TITLE
chore: move engineering vulnerabilities extract to earlier

### DIFF
--- a/hokusai/production.yml
+++ b/hokusai/production.yml
@@ -92,7 +92,7 @@ kind: CronJob
 metadata:
   name: frequency-vulnerabilities-extract
 spec:
-  schedule: 01 5 * * *
+  schedule: 01 0 * * *
   concurrencyPolicy: Forbid
   jobTemplate:
     spec:


### PR DESCRIPTION
We keep getting alerted that the vulnerabilities extract isn't fresh in #data-alerts as the extract is currently scheduled to run a few hours after the freshness check takes place (usually around 2.30am). I'm moving it a bit earlier to make the alerts shh.