### PR TITLE
refactor: remove unused config values

### DIFF
--- a/lib/config.rb
+++ b/lib/config.rb
@@ -12,9 +12,7 @@ class Config
       aws_region: ENV['AWS_REGION'] || 'us-east-1',
       aws_secret_access_key: ENV['AWS_SECRET_ACCESS_KEY'],
       dd_agent_host: ENV['DD_AGENT_HOST'] || 'localhost',
-      github_access_token: ENV['GITHUB_ACCESS_TOKEN'],
-      redshift_url: ENV['REDSHIFT_URL'],
-      extracts_bucket: ENV['EXTRACTS_BUCKET'] || 'artsy-data-platform-production'
+      github_access_token: ENV['GITHUB_ACCESS_TOKEN']
     }.tap do |config|
       warn "Loading config #{config.map { |k, v| [k, v&.gsub(/.(?<=.{3})/, '*')].join(':') }.join(', ')}"
     end


### PR DESCRIPTION
I'm removing these unused config values so it's easier to tell in future where we actually are connecting to Redshift or running extracts.